### PR TITLE
feature: rudimentary way to keep jobs asleep until market opens

### DIFF
--- a/src/market.ts
+++ b/src/market.ts
@@ -1,0 +1,42 @@
+import { firebase } from './firebase';
+import {
+	IsoString,
+	time
+	} from '@prmichaelsen/ts-utils';
+
+export const market = {
+	meta: {
+		async dateMarketCloses() {
+			try {
+				return time.parse((
+					await firebase.database()
+					.ref('market/meta/dateMarketCloses')
+					.once('value')
+				).val());
+			} catch (e) {
+				throw e;
+			}
+		},
+		async dateMarketOpens() {
+			try {
+				return time.parse((
+					await firebase.database()
+					.ref('market/meta/dateMarketOpens')
+					.once('value')
+				).val());
+			} catch (e) {
+				throw e;
+			}
+		},
+		async isOpen() {
+			try {
+				return (await firebase.database()
+					.ref('market/meta/isOpen')
+					.once('value')
+				).val() === true;
+			} catch (e) {
+				throw e;
+			}
+		},
+	}
+}


### PR DESCRIPTION
This is a really shoddy way to keep the jobs in pending state while the market is out of hours.

Basically, the thread that is handling the pending job literally sleeps until the market is open. It does this by sleeping `nextOpen - now` milliseconds.

I was thinking some alternatives to this are:
 * real cron jobs
 * node-cron job
 * firebase queue
 * "subscribe" jobs to events

The latter would mean that I would maintain a list of subscriptions between jobs and events. Then, whenever that event is triggered, all subscriptions would receive it. Could be useful.