### PR TITLE
bugfix: correct dateMarketCloses

### DIFF
--- a/src/tradier.test.ts
+++ b/src/tradier.test.ts
@@ -1,0 +1,66 @@
+import {
+	dateMarketCloses,
+	dateMarketOpens,
+	MarketHours
+	} from './tradier';
+import { time } from '@prmichaelsen/ts-utils';
+
+describe('dateMarketCloses', () => {
+	it('gets the next market close', () => {
+		// Assemble
+		const marketHours: MarketHours[] = [
+			{
+				open: time.parse('2018-11-08T14:30:00.000Z'),
+				close: time.parse('2018-11-08T21:00:00.000Z'),
+			},
+			{
+				open: time.parse('2018-11-09T14:30:00.000Z'),
+				close: time.parse('2018-11-09T21:00:00.000Z'),
+			},
+			{
+				open: time.parse('2018-11-12T14:30:00.000Z'),
+				close: time.parse('2018-11-12T21:00:00.000Z'),
+			},
+		];
+
+		// Act
+		// one hour after close on 11-09
+		const now =  time.parse('2018-11-09T22:00:00.000Z');
+		const result =
+			dateMarketCloses(marketHours, now);
+		const expected = '2018-11-12T21:00:00.000Z';
+
+		// Assert
+		expect(result).toEqual(expected)
+	});
+});
+
+describe('dateMarketOpens', () => {
+	it('gets the next market open', () => {
+		// Assemble
+		const marketHours: MarketHours[] = [
+			{
+				open: time.parse('2018-11-08T14:30:00.000Z'),
+				close: time.parse('2018-11-08T21:00:00.000Z'),
+			},
+			{
+				open: time.parse('2018-11-09T14:30:00.000Z'),
+				close: time.parse('2018-11-09T21:00:00.000Z'),
+			},
+			{
+				open: time.parse('2018-11-12T14:30:00.000Z'),
+				close: time.parse('2018-11-12T21:00:00.000Z'),
+			},
+		];
+
+		// Act
+		// one hour after close on 11-09
+		const now =  time.parse('2018-11-09T22:00:00.000Z');
+		const result =
+			dateMarketOpens(marketHours, now);
+		const expected = '2018-11-12T14:30:00.000Z';
+
+		// Assert
+		expect(result).toEqual(expected)
+	});
+});

--- a/src/tradier.ts
+++ b/src/tradier.ts
@@ -116,7 +116,7 @@ export function dateMarketCloses(marketHours: MarketHours[], date?: IsoString): 
 	for (let i = 0; (i < marketHours.length - 1) && !result; i++ ) {
 		const close = closeTimes[i];
 		const nextClose = closeTimes[i + 1];
-		if (time.isSameOrAfter(now, close) || time.isBefore(now, nextClose)) {
+		if (time.isSameOrAfter(now, close) && time.isBefore(now, nextClose)) {
 			result = nextClose;
 		}
 	}


### PR DESCRIPTION
updates the `dateMarketCloses` function so that it gets the real next close date, instead of the first close date past the nearest open time